### PR TITLE
feat: Adição de valores médios nos gráficos

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn codigo.app:app

--- a/codigo/static/css/style.css
+++ b/codigo/static/css/style.css
@@ -551,3 +551,45 @@ footer p {
     font-size: 0.7rem;
   }
 }
+
+.botao-anomalia {
+  margin: 10px 0;
+  padding: 8px 15px;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.3s ease;
+}
+
+.botao-anomalia:hover {
+  background-color: #45a049;
+}
+
+.botao-anomalia:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(76, 175, 80, 0.5);
+}
+
+@media (max-width: 768px) {
+  .botao-anomalia {
+    font-size: 12px; 
+    padding: 6px 12px; 
+  }
+}
+
+.texto-explicativo {
+  font-size: 20px;
+  color: #555;
+  margin-bottom: 10px;
+  text-align: center;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .texto-explicativo {
+    font-size: 12px; 
+  }
+}

--- a/codigo/static/scripts/charts.js
+++ b/codigo/static/scripts/charts.js
@@ -220,7 +220,7 @@ function renderizarGrafico(tagId, dados) {
     textoExplicativo.className = 'texto-explicativo';
     container.insertBefore(textoExplicativo, container.firstChild);
   }
-  textoExplicativo.innerHTML = 'Clique em "Mostrar Anomalias" para destacar gastos que excedem 20% da média do período.';
+  textoExplicativo.innerHTML = 'Clique em "Mostrar Anomalias" para destacar gastos que excedem 40% da média do período.';
 
   window.addEventListener("resize", () => {
     atualizarECelular();

--- a/codigo/static/scripts/charts.js
+++ b/codigo/static/scripts/charts.js
@@ -23,7 +23,7 @@ const calcularMedias = (dados) => {
   if (!valores || valores.length === 0) return null;
   
   const media = valores.reduce((a, b) => a + b, 0) / valores.length;
-  const limiteSuperior = media * 1.2; // 20% acima da média
+  const limiteSuperior = media * 1.4; // 40% acima da média
   
   const alertas = valores.map((valor, index) => {
     return valor > limiteSuperior ? {

--- a/codigo/static/scripts/charts.js
+++ b/codigo/static/scripts/charts.js
@@ -117,10 +117,10 @@ const montarLayoutDoGrafico = (tagId, dados) => {
   const mediasEAlertas = calcularMedias(dados);
   
   // Cria anotações para alertas
-  const annotacao = [];
+  const annotations = [];
   if (mediasEAlertas && mediasEAlertas.alertas.length > 0) {
     mediasEAlertas.alertas.forEach(alerta => {
-      annotacao.push({
+      annotations.push({
         x: alerta.ano,
         y: alerta.valor,
         text: `⚠️ +${alerta.variacao.toFixed(1)}%`,
@@ -175,7 +175,7 @@ const montarLayoutDoGrafico = (tagId, dados) => {
       r: 50,
       b: eCelular ? 80 : 60,
     },
-    annotacao: annotacao
+    annotations: annotations
   };
 };
 


### PR DESCRIPTION
## Descrição

Implementação de uma nova funcionalidade nos gráficos que adiciona uma linha de média dos valores e alertas visuais para gastos acima da média. A funcionalidade inclui:
- Linha tracejada vermelha indicando a média dos valores
- Alertas (⚠️) para valores que excedem 20% da média
- Tooltips informativos mostrando a variação percentual

## Tipo de mudança

- [ ] Correção de bug
- [x] Nova funcionalidade
- [ ] Alteração de funcionalidade existente
- [ ] Refatoração de código
- [ ] Atualização de documentação

## Issue Relacionada

- Issue #22 

## Testes

As alterações foram testadas nos seguintes cenários:
- Visualização em dispositivos desktop
- Diferentes conjuntos de dados (compras e despesas por órgão)
- Comportamento responsivo da linha de média
- Exibição correta dos alertas quando valores excedem o limite

## Questões em aberto

- Avaliar se o limite de 20% acima da média é adequado para todos os tipos de gráficos
- Considerar adicionar configurações personalizáveis para os limites de alerta

## Checklist

- [x] O código segue as diretrizes do repositório
- [x] O código foi testado
- [x] A documentação foi atualizada