### PR TITLE
docs: Adiciona ata de reunião do dia 27/01

### DIFF
--- a/docs/atas/atas_reunioes_semanais/ata_27_01_25.md
+++ b/docs/atas/atas_reunioes_semanais/ata_27_01_25.md
@@ -1,0 +1,17 @@
+# Ata de reunião
+
+## Dados
+
+- Temática: Reunião semanal;
+- Data: 27/01/2025;
+- Hora de início: 21:00;
+- Hora de conclusão: 22:00;
+- Participantes: Artur Mendonça Arruda; Gabriel da Cunha Barbaceli; Gabriel Lopes de Amorim; João Pedro Costa; Julia Gabriela Cunha Paulino; Lucas Mendonça Arruda;
+- Local: Discord;
+- Autor: Artur Mendonça Arruda.
+
+## Conteúdo
+
+- Retrospectiva da Sprint 10;
+- Definição de funções para sprint 11;
+- Discussão e ajuste do valor de referência para gastos acima da média (alterado de 20% para 40% do valor médio).


### PR DESCRIPTION
---
Ata de reunião do dia 27/01/2025
---

## Descrição
Foi adicionada a ata da reunião semanal onde foram discutidos os seguintes tópicos:
- Retrospectiva da Sprint 10
- Definição das atividades para Sprint 11
- Ajuste do valor de referência para gastos acima da média (de 20% para 40%)

## Tipo de mudança

- [ ] Correção de bug
- [ ] Nova funcionalidade
- [ ] Alteração de funcionalidade existente
- [ ] Refatoração de código
- [x] Atualização de documentação

## Checklist

- [x] O código segue as diretrizes do repositório
- [x] O código foi testado
- [x] A documentação foi atualizada
